### PR TITLE
Add service plugin with Spring Boot and container publishing defaults

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -1,12 +1,13 @@
-# TheZeroLabs Library Gradle Plugin
+# TheZeroLabs Gradle Plugins
 
-The `library` module provides a Gradle plugin (`net.thezerolabs.gradle.library`) that standardizes JVM project setup and optionally wires in TheZeroLabs BOM and GitHub Packages publishing.
+The `library` module provides multiple Gradle plugins that standardize JVM and service projects while wiring in TheZeroLabs opinionated defaults.
 
 ## Plugin ID
 
 - `net.thezerolabs.gradle.library`
+- `net.thezerolabs.gradle.service`
 
-## What the plugin does
+## What the library plugin does
 
 - Sets Java toolchain to Java 24 when not explicitly configured.
 - Adds Maven Central, Spring Releases, and TheZeroLabs GitHub Packages repositories for dependency resolution by default.
@@ -65,7 +66,7 @@ pluginManagement {
 
 ## Configuration (extension)
 
-The plugin exposes an extension named `zero`:
+Both plugins expose an extension named `zero`:
 
 Kotlin DSL:
 ```kotlin
@@ -90,6 +91,26 @@ zero {
     // Credentials (used for dependency resolution and publishing; if not set, falls back to env GITHUB_ACTOR / GITHUB_TOKEN)
     username.set("${System.getenv("GPR_USER")}")
     token.set("${System.getenv("GPR_TOKEN")}")
+
+    // Spring Boot service settings (service plugin)
+    bootMainClass.set("com.example.Application")
+
+    container {
+        // Optional explicit image. Defaults to ghcr.io/<githubOwner>/<githubRepo>
+        image.set("123456789012.dkr.ecr.us-east-1.amazonaws.com/my-service")
+        // Tags to publish. Defaults to project version when present.
+        tags.set(listOf("latest", "${project.version}"))
+
+        // GitHub Container Registry publishing (enabled by default)
+        enableGithubPublishing.set(true)
+
+        // Amazon ECR support (disabled by default)
+        enableEcrPublishing.set(true)
+        ecrRegistry.set("123456789012.dkr.ecr.us-east-1.amazonaws.com")
+        ecrRepository.set("my-service")
+        ecrUsername.set("AWS")
+        ecrPassword.set(System.getenv("AWS_ECR_PASSWORD"))
+    }
 }
 ```
 
@@ -110,8 +131,30 @@ zero {
     // Credentials (used for dependency resolution and publishing)
     username = System.getenv('GPR_USER')
     token = System.getenv('GPR_TOKEN')
+
+    // Spring Boot service settings (service plugin)
+    bootMainClass = 'com.example.Application'
+
+    container {
+        image = '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-service'
+        tags = ['latest', project.version]
+        enableGithubPublishing = true
+        enableEcrPublishing = true
+        ecrRegistry = '123456789012.dkr.ecr.us-east-1.amazonaws.com'
+        ecrRepository = 'my-service'
+        ecrUsername = 'AWS'
+        ecrPassword = System.getenv('AWS_ECR_PASSWORD')
+    }
 }
 ```
+
+## What the service plugin adds
+
+- Applies the library plugin automatically.
+- Adds the Spring Boot Gradle plugin and lets you set the `bootMainClass` via `zero.bootMainClass`.
+- Applies the Jib plugin to build container images.
+- Derives a GitHub Container Registry image (`ghcr.io/<owner>/<repo>`) and configures credentials from GitHub environment variables.
+- Allows publishing to Amazon ECR by configuring `zero.container` (registry, repository, credentials, or environment variables).
 
 ## Using the BOM via the plugin
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -19,6 +19,12 @@ gradlePlugin {
             description = "Enforces Java 24+ toolchain and adds TheZeroLabs BOM as a default platform dependency."
             implementationClass = "net.thezerolabs.gradle.library.LibraryPlugin"
         }
+        create("service") {
+            id = "net.thezerolabs.gradle.service"
+            displayName = "TheZeroLabs Service Convention Plugin"
+            description = "Extends the library plugin with Spring Boot and container image publishing defaults."
+            implementationClass = "net.thezerolabs.gradle.library.ServicePlugin"
+        }
     }
 }
 

--- a/library/src/main/kotlin/net/thezerolabs/gradle/library/LibraryPlugin.kt
+++ b/library/src/main/kotlin/net/thezerolabs/gradle/library/LibraryPlugin.kt
@@ -16,6 +16,25 @@ import org.gradle.kotlin.dsl.maven
 import org.gradle.kotlin.dsl.mavenCentral
 import javax.inject.Inject
 
+open class ContainerExtension @Inject constructor(objects: ObjectFactory) {
+    /** Fully qualified image name to publish. If blank, derived from GitHub or ECR settings. */
+    val image: Property<String> = objects.property(String::class.java)
+    /** Additional tags to publish. Defaults to the project version when available. */
+    val tags: ListProperty<String> = objects.listProperty(String::class.java)
+    /** Whether to automatically configure publishing to GitHub Container Registry (ghcr.io). */
+    val enableGithubPublishing: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+    /** Whether to configure publishing to Amazon ECR. */
+    val enableEcrPublishing: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+    /** Optional explicit ECR registry endpoint (e.g. 123456789012.dkr.ecr.us-east-1.amazonaws.com). */
+    val ecrRegistry: Property<String> = objects.property(String::class.java)
+    /** Optional ECR repository name. */
+    val ecrRepository: Property<String> = objects.property(String::class.java)
+    /** Optional username for ECR authentication (defaults to AWS when not provided). */
+    val ecrUsername: Property<String> = objects.property(String::class.java)
+    /** Optional password/token for ECR authentication. */
+    val ecrPassword: Property<String> = objects.property(String::class.java)
+}
+
 open class ZeroExtension @Inject constructor(objects: ObjectFactory) {
     /** Group of the published BOM to use when the :bom project is not present. */
     val bomGroup: Property<String> = objects.property(String::class.java).convention("net.thezerolabs.gradle")
@@ -40,6 +59,10 @@ open class ZeroExtension @Inject constructor(objects: ObjectFactory) {
     val token: Property<String> = objects.property(String::class.java)
     /** Whether to auto-configure GitHub Packages publishing repository. */
     val enableGithubPublishing: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+    /** Optional Spring Boot main class (used by the service plugin). */
+    val bootMainClass: Property<String> = objects.property(String::class.java)
+    /** Container/image configuration (used by the service plugin). */
+    val container: ContainerExtension = objects.newInstance(ContainerExtension::class.java)
 }
 
 class LibraryPlugin : Plugin<Project> {

--- a/library/src/main/kotlin/net/thezerolabs/gradle/library/ServicePlugin.kt
+++ b/library/src/main/kotlin/net/thezerolabs/gradle/library/ServicePlugin.kt
@@ -1,0 +1,189 @@
+package net.thezerolabs.gradle.library
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.getByType
+import java.util.LinkedHashSet
+
+class ServicePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply("net.thezerolabs.gradle.library")
+        project.pluginManager.apply("org.springframework.boot")
+        project.pluginManager.apply("com.google.cloud.tools.jib")
+
+        val zero = project.extensions.getByType<ZeroExtension>()
+
+        configureSpringBoot(project, zero)
+        configureJib(project, zero)
+    }
+
+    private fun configureSpringBoot(project: Project, zero: ZeroExtension) {
+        project.pluginManager.withPlugin("org.springframework.boot") {
+            val springBootExt = project.extensions.findByName("springBoot") ?: return@withPlugin
+            val mainClassProperty = findMainClassProperty(springBootExt)
+
+            mainClassProperty?.convention(zero.bootMainClass)
+            project.afterEvaluate {
+                val mainClass = zero.bootMainClass.orNull
+                if (!mainClass.isNullOrBlank()) {
+                    mainClassProperty?.set(mainClass)
+                }
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun findMainClassProperty(extension: Any): Property<String>? {
+        val getter = extension.javaClass.methods.firstOrNull { method ->
+            method.name == "getMainClass" && method.parameterCount == 0
+        } ?: return null
+
+        val result = runCatching { getter.invoke(extension) }.getOrNull()
+        return result as? Property<String>
+    }
+
+    private fun configureJib(project: Project, zero: ZeroExtension) {
+        project.pluginManager.withPlugin("com.google.cloud.tools.jib") {
+            val jib = project.extensions.findByName("jib") ?: return@withPlugin
+            val container = zero.container
+
+            val env = { name: String -> project.providers.environmentVariable(name).orNull }
+            val prop = { name: String -> project.providers.gradleProperty(name).orNull ?: project.findProperty(name)?.toString() }
+
+            val (ghOwner, ghRepo) = resolveGithubOwnerRepo(project, zero)
+
+            val useEcr = container.enableEcrPublishing.orNull == true ||
+                !container.ecrRegistry.orNull.isNullOrBlank() ||
+                !container.ecrRepository.orNull.isNullOrBlank()
+
+            val image = container.image.orNull?.takeIf { it.isNotBlank() } ?: if (useEcr) {
+                val registry = container.ecrRegistry.orNull ?: env("AWS_ECR_REGISTRY")
+                val repository = container.ecrRepository.orNull ?: env("AWS_ECR_REPOSITORY") ?: project.name
+                if (!registry.isNullOrBlank()) {
+                    listOf(registry.trimEnd('/'), repository.trim('/')).joinToString("/") { it.lowercase() }
+                } else null
+            } else if (container.enableGithubPublishing.orNull != false) {
+                if (!ghOwner.isNullOrBlank() && !ghRepo.isNullOrBlank()) {
+                    "ghcr.io/${ghOwner.lowercase()}/${ghRepo.lowercase()}"
+                } else null
+            } else null
+
+            if (!image.isNullOrBlank()) {
+                setStringProperty(jib, "setImage", image, "to")
+            }
+
+            val defaultTags = if (container.tags.isPresent && container.tags.orNull?.isNotEmpty() == true) {
+                container.tags.get()
+            } else {
+                val version = project.version.toString()
+                if (version.equals("unspecified", ignoreCase = true)) emptyList() else listOf(version)
+            }
+            if (defaultTags.isNotEmpty()) {
+                val tags = LinkedHashSet(defaultTags.filter { it.isNotBlank() }.map { it.trim() })
+                setCollectionProperty(jib, "setTags", tags, "to")
+            }
+
+            if (useEcr) {
+                val username = container.ecrUsername.orNull
+                    ?: env("AWS_ECR_USERNAME")
+                    ?: "AWS"
+                val password = container.ecrPassword.orNull
+                    ?: env("AWS_ECR_PASSWORD")
+                    ?: env("AWS_ECR_TOKEN")
+
+                if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+                    setAuth(jib, username, password, "to")
+                }
+            } else if (container.enableGithubPublishing.orNull != false) {
+                val user = zero.username.orNull ?: prop("gpr.user") ?: env("GPR_USER") ?: env("GITHUB_ACTOR")
+                val token = zero.token.orNull ?: prop("gpr.token") ?: env("GPR_TOKEN") ?: env("GITHUB_TOKEN")
+                if (!user.isNullOrBlank() && !token.isNullOrBlank()) {
+                    setAuth(jib, user, token, "to")
+                }
+            }
+
+            val extraCredHelper = env("JIB_CRED_HELPER") ?: prop("jib.credHelper")
+            if (!extraCredHelper.isNullOrBlank()) {
+                setStringProperty(jib, "setCredHelper", extraCredHelper, "to")
+            }
+        }
+    }
+
+    private fun setStringProperty(target: Any, setterName: String, value: String, nested: String? = null) {
+        val receiver = nested?.let { getNested(target, it) } ?: target
+        val method = receiver?.javaClass?.methods?.firstOrNull { it.name == setterName && it.parameterCount == 1 && it.parameterTypes[0] == String::class.java }
+        method?.invoke(receiver, value)
+    }
+
+    private fun setCollectionProperty(target: Any, setterName: String, value: Set<String>, nested: String? = null) {
+        val receiver = nested?.let { getNested(target, it) } ?: target
+        val method = receiver?.javaClass?.methods?.firstOrNull { it.name == setterName && it.parameterCount == 1 }
+        method?.invoke(receiver, value)
+    }
+
+    private fun setAuth(target: Any, username: String, password: String, nested: String? = null) {
+        val receiver = nested?.let { getNested(target, it) } ?: target
+        val auth = receiver?.javaClass?.methods?.firstOrNull { it.name == "getAuth" && it.parameterCount == 0 }?.invoke(receiver)
+        if (auth != null) {
+            val userSetter = auth.javaClass.methods.firstOrNull { it.name == "setUsername" && it.parameterCount == 1 }
+            val passSetter = auth.javaClass.methods.firstOrNull { it.name == "setPassword" && it.parameterCount == 1 }
+            userSetter?.invoke(auth, username)
+            passSetter?.invoke(auth, password)
+        }
+    }
+
+    private fun getNested(target: Any, nested: String): Any? {
+        val getter = target.javaClass.methods.firstOrNull { it.name.equals("get${nested.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }}", ignoreCase = true) && it.parameterCount == 0 }
+        return getter?.invoke(target)
+    }
+
+    private fun resolveGithubOwnerRepo(project: Project, zero: ZeroExtension): Pair<String?, String?> {
+        val env = { name: String -> project.providers.environmentVariable(name).orNull }
+        val prop = { name: String -> project.providers.gradleProperty(name).orNull ?: project.findProperty(name)?.toString() }
+
+        var owner = zero.githubOwner.orNull ?: env("GITHUB_OWNER") ?: env("GITHUB_REPOSITORY")?.substringBefore('/')
+            ?: prop("gpr.owner")
+        var repo = zero.githubRepo.orNull ?: env("GITHUB_REPOSITORY")?.substringAfter('/') ?: prop("gpr.repo")
+
+        if (owner.isNullOrBlank() || repo.isNullOrBlank()) {
+            val gitConfig = project.rootProject.file(".git/config")
+            if (gitConfig.isFile) {
+                val lines = gitConfig.readLines()
+                var inOrigin = false
+                var url: String? = null
+                for (raw in lines) {
+                    val line = raw.trim()
+                    if (line.startsWith("[") && line.endsWith("]")) {
+                        inOrigin = line.equals("[remote \"origin\"]", ignoreCase = true)
+                        continue
+                    }
+                    if (inOrigin && line.startsWith("url")) {
+                        url = line.substringAfter('=').trim()
+                        break
+                    }
+                }
+                if (!url.isNullOrBlank()) {
+                    val regexes = listOf(
+                        Regex("""(?i)git@([^:]+):([^/]+)/([^/]+?)(?:\\.git)?$"""),
+                        Regex("""(?i)(?:https?|ssh|git)://([^/]+)/([^/]+)/([^/]+?)(?:\\.git)?$""")
+                    )
+                    for (regex in regexes) {
+                        val match = regex.find(url)
+                        if (match != null && match.groupValues.size >= 4) {
+                            val host = match.groupValues[1]
+                            if (!host.contains("github", ignoreCase = true)) break
+                            owner = owner ?: match.groupValues[2]
+                            repo = repo ?: match.groupValues[3]
+                            break
+                        }
+                    }
+                }
+            }
+        }
+
+        return owner?.takeIf { it.isNotBlank() } to repo?.takeIf { it.isNotBlank() }
+    }
+
+    private fun String.trim(char: Char): String = trimStart(char).trimEnd(char)
+}


### PR DESCRIPTION
## Summary
- extend the shared zero extension with Spring Boot and container publishing options
- add a service plugin that applies Spring Boot and configures Jib for GitHub and optional ECR pushes
- register the new plugin and document the additional service configuration options

## Testing
- ./gradlew :library:build

------
https://chatgpt.com/codex/tasks/task_e_68d8c13d457c8321bf17b01c2d3f7df5